### PR TITLE
Removes quotes and simplifies INSTALL_PATH

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,19 +1,17 @@
 #!/bin/sh
 
-INSTALL_PATH="$(dirname "$(test -L "$BASH_SOURCE" && readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")")"
-
-cd "$INSTALL_PATH"
+INSTALL_PATH="$(cd $(dirname $0)/../ ; pwd -P )"
 
 cat > "$HOME/.vimrc.go" <<EOF
 set runtimepath^="$INSTALL_PATH"
 
-source "$INSTALL_PATH/vimrc/basic.vim"
-source "$INSTALL_PATH/vimrc/filetypes.vim"
-source "$INSTALL_PATH/vimrc/plugins.vim"
-source "$INSTALL_PATH/vimrc/extended.vim"
+source $INSTALL_PATH/vimrc/basic.vim
+source $INSTALL_PATH/vimrc/filetypes.vim
+source $INSTALL_PATH/vimrc/plugins.vim
+source $INSTALL_PATH/vimrc/extended.vim
 
 try
-  source "$INSTALL_PATH/custom_config.vim"
+  source $INSTALL_PATH/custom_config.vim
 catch
 endtry
 EOF


### PR DESCRIPTION
In another machine of mine, the install failed because of the quotes in the ~/.vimrc.go. Hence, I removed them. It might present some issues if one uses whitespaces in the installation path. However, I have no time to change that right now.

Besides that, someone pointed me that the way I was getting the INSTALL_PATH was not reliable. So I changed the the script to use the solution at [1].

[1] http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
