### PR TITLE
added christoomey/vim-tmux-navigator and key maps <c-h/j/k/l> for nav…

### DIFF
--- a/vimrc/extended.vim
+++ b/vimrc/extended.vim
@@ -25,3 +25,10 @@ nmap <silent> <leader>n :silent :nohlsearch<cr>
 
 " Make sure that CTRL-A (used by gnu screen) is redefined
 noremap <leader>inc <C-A>
+
+" Make Ctrl-H J K L work for tmux pane navigation
+let g:tmux_navigator_no_mappings = 1
+nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
+nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
+nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
+nnoremap <silent> <c-l> :TmuxNavigateRight<cr>


### PR DESCRIPTION
* added Plugin christoomey/vim-tmux-navigator
```
This plugin is a repackaging of Mislav Marohnić's tmux-navigator configuration described 
in this gist.  When combined with a set of tmux key bindings, the plugin will allow you to 
navigate seamlessly between vim and tmux splits using a consistent set of hotkeys.
```
* added keymaps for navigation both inside panes of vim, and outside panes in tmux:
```
nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
nnoremap <silent> <c-l> :TmuxNavigateRight<cr>
```